### PR TITLE
Fixed error when running `snip` on empty line. Closes #41.

### DIFF
--- a/scripts/snip
+++ b/scripts/snip
@@ -3,25 +3,41 @@
 [[ -z $SNIPPETS ]] && echo "SNIPPETS directory undefined" && exit 1
 
 snip() {
-    local name="$1"
-    shift
-    local path="$SNIPPETS/$name"
-    if [[ -r $path ]]; then
-        local buf="$(<$path)"
-        local -i n=1
-        if [[ $# > 0 ]]; then
-            for arg in $@;do
-                buf=${buf//\{$n\}/$arg}
-                ((n++))
-            done
-        else
-            while IFS=$'\n' read -r argline; do 
-                IFS=" " snip $name $argline
-            done
-            return
-        fi
-        echo "$buf"
+  local name="$1"
+  shift
+  local path="$SNIPPETS/$name"
+  
+  if [[ -r $path ]]; then
+
+    local buf="$(<$path)"
+    if [[ -s /dev/stdin ]]; then
+      local in="$(</dev/stdin)"
+    else
+      local in=""
     fi
+
+    if [[ $# = 0 && -z $in ]]; then
+      echo "$buf"
+      return
+    fi
+
+    if [[ $# > 0 ]]; then
+      local -i n=1
+      for arg in $@; do
+        buf=${buf//\{$n\}/$arg}
+        ((n++))
+      done
+      echo "$buf"
+    else
+      while IFS=$'\n' read -r argline; do
+        if [[ -n $argline ]]; then
+          IFS=" " snip $name $argline
+        fi
+      done
+    fi
+
+  fi
 }
 
 snip "$@"
+


### PR DESCRIPTION
Closes #41
